### PR TITLE
Documenting the proposal process on Bug triage for Mojaloop Open Source

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -15,6 +15,7 @@
   * [Standards](contributors-guide/standards/README.md)
     * [Versioning](contributors-guide/standards/versioning.md)
     * [Creating new Features](contributors-guide/standards/creating-new-features.md)
+    * [ML OSS Bug Triage](contributors-guide/standards/triaging-ml-oss-bugs.md)
   * [Tools and Technologies](contributors-guide/tools-and-technologies/README.md)
     * [Pragmatic REST](contributors-guide/tools-and-technologies/pragmatic-rest.md)
     * [Code Quality Metrics](contributors-guide/tools-and-technologies/code-quality-metrics.md)

--- a/contributors-guide/standards/triaging-ml-oss-bugs.md
+++ b/contributors-guide/standards/triaging-ml-oss-bugs.md
@@ -1,0 +1,42 @@
+# Triaging Mojaloop OSS bugs
+
+### Raising a bug / issue
+
+If there is a bug or issue in general an issue is logged as a bug or feature request on the [project](https://github.com/mojaloop/project/issues/new/choose) repository and in some cases linked to an issue logged on the repository for that specific component.
+
+There is a bug [template](https://github.com/mojaloop/project/issues/new?assignees=&labels=bug&template=bug_report.md&title=) that can be used and encourages use of details such as versions, expected results and other details, which help with triage and reproducing the issue.
+
+### Once a bug is logged
+
+1. Typically, the bug is initially triaged in the [#ml-oss-bug-triage](https://mojaloop.slack.com/messages/CMCVBHPUH) public channel on Mojaloop Slack
+2. For Security and other sensitive issues, the bug is triaged on a private channel with current contributors, before information is made public at an appropriate time.
+3. During bug triage, priority and severity are assigned to the bug after majority consensus usually
+4. Based on the priority and severity the bug is taken up by the Core team or other contributors based on a collaborative effort.
+5. Once it is taken up, conversation and updates happen on the slack channl, but mostly on the issue itself.
+
+### Triage
+
+1. The discussion regarding the issue is open to a public for normal bugs / issues
+2. However, to start with, the voting rights are given to current contributors and stakeholders.
+3. Based on the discussions, a final call on the priority and severity of the issue is made by the Program Manager.
+4. If you think you need a vote, please reach out to Kim or Sam.
+5. Here are the voting members [14] for triaging bugs to start with.
+    1. Adrian Hope-Bailie
+    1. James Bush
+    1. Kim Walters
+    1. Lewis Daly
+    1. Miguel deBarros
+    1. Matt Bohan
+    1. Miller Abel
+    1. Neal Donnan
+    1. Nico Duvenage
+    1. Rajiv Mothilal
+    1. Rob Reeve
+    1. Sam Kummary
+    1. Sri Miryala
+    1. Warren Carew
+6. The list and the process will be updated as it evolves, this is a proposal to start with do a Pilot on.
+
+### Merge into Mojaloop Repo
+
+Once the feature is completed create a PR from your Feature Branch into the `master` branch on the Mojaloop repository \(not your personal repo\) for approval, and check validations \(e.g. unit tests, code coverage, etc executed via CircieCI\).

--- a/contributors-guide/standards/triaging-ml-oss-bugs.md
+++ b/contributors-guide/standards/triaging-ml-oss-bugs.md
@@ -36,7 +36,3 @@ There is a bug [template](https://github.com/mojaloop/project/issues/new?assigne
     1. Sri Miryala
     1. Warren Carew
 6. The list and the process will be updated as it evolves, this is a proposal to start with do a Pilot on.
-
-### Merge into Mojaloop Repo
-
-Once the feature is completed create a PR from your Feature Branch into the `master` branch on the Mojaloop repository \(not your personal repo\) for approval, and check validations \(e.g. unit tests, code coverage, etc executed via CircieCI\).


### PR DESCRIPTION
Created two slack channels as well on Mojaloop Slack, one public and one for sensitive issues.