### PR TITLE
Fix error in ALS' sequence diagram for DEL Participants

### DIFF
--- a/mojaloop-technical-overview/account-lookup-service/assets/diagrams/sequence/seq-acct-lookup-del-participants-7.1.2.plantuml
+++ b/mojaloop-technical-overview/account-lookup-service/assets/diagrams/sequence/seq-acct-lookup-del-participants-7.1.2.plantuml
@@ -174,7 +174,7 @@ group Get Party Details
         ALS_CENTRALSERVICE_ENDPOINT_CONFIG_DAO --> ALS_PARTICIPANT_HANDLER: List of PayerFSP Participant Callback Endpoints
         deactivate ALS_CENTRALSERVICE_ENDPOINT_CONFIG_DAO
 
-        ALS_PARTICIPANT_HANDLER -> ALS_PARTICIPANT_HANDLER: Match PayerFSP Participant Callback Endpoints for\nFSPIOP_CALLBACK_URL_PARTIES_PUT
+        ALS_PARTICIPANT_HANDLER -> ALS_PARTICIPANT_HANDLER: Match PayerFSP Participant Callback Endpoints for\nFSPIOP_CALLBACK_URL_PARTICIPANT_PUT
 
         '********************* Get PayerFSP Participant End-point Information - END ************************
 
@@ -194,7 +194,7 @@ group Get Party Details
         ALS_CENTRALSERVICE_ENDPOINT_CONFIG_DAO --> ALS_PARTICIPANT_HANDLER: List of PayerFSP Participant Callback Endpoints
         deactivate ALS_CENTRALSERVICE_ENDPOINT_CONFIG_DAO
 
-        ALS_PARTICIPANT_HANDLER -> ALS_PARTICIPANT_HANDLER: Match PayerFSP Participant Callback Endpoints for\nFSPIOP_CALLBACK_URL_PARTIES_PUT_ERROR
+        ALS_PARTICIPANT_HANDLER -> ALS_PARTICIPANT_HANDLER: Match PayerFSP Participant Callback Endpoints for\nFSPIOP_CALLBACK_URL_PARTICIPANT_PUT_ERROR
 
         '********************* Get PayerFSP Participant End-point Information - END ************************
 


### PR DESCRIPTION
- Changed `FSPIOP_CALLBACK_URL_PARTIES_PUT` to `FSPIOP_CALLBACK_URL_PARTICIPANT_PUT` in sequence diagram for "DEL Participants"