### PR TITLE
Updated documentation for Linux setup.

### DIFF
--- a/deployment-guide/README.md
+++ b/deployment-guide/README.md
@@ -12,7 +12,7 @@ The document is intended for an audience with a stable technical knowledge that 
 - [Postman](#6-postman)
   - [Installing Postman](#61-installing-postman)
   - [Setup Postman](#62-setup-postman)
-  
+
 ### 1. Pre-requisites
 
 A list of the pre-requisite tool set required for the deployment of Mojaloop;
@@ -39,7 +39,7 @@ This provides environment resource recommendations with a view of the infrastruc
 **Resources Requirements:**
 
 * Control Plane (i.e. Master Node)
-  
+
   [https://kubernetes.io/docs/setup/cluster-large/#size-of-master-and-master-components](https://kubernetes.io/docs/setup/cluster-large/#size-of-master-and-master-components)
 
   * 3x Master Nodes for future node scaling and HA (High Availability)
@@ -92,7 +92,7 @@ Insure **kubectl** is installed. A complete set of installation instruction are 
    ```bash
    kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
    ```
-   
+
    If you have installed MicroK8s, **enable the MicroK8s** dashboard;
    ```bash
    microk8s.enable dashboard
@@ -110,19 +110,19 @@ Insure **kubectl** is installed. A complete set of installation instruction are 
    ```
 
 4. Open URI in default browser:
-    
+
    ```
    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
    ```
 
    Select **Token**. Generate a token to use there by: _Windows replace `grep` with `findstr`_
-   
+
    ```bash
    kubectl -n kube-system get secrets | grep dashboard-token
    ```
 
    The token to use is shown on the last line of the output of that command;
-   
+
    ```bash
    kubectl -n kube-system describe secrets/kubernetes-dashboard-token-btbwf
    ```
@@ -131,7 +131,7 @@ Insure **kubectl** is installed. A complete set of installation instruction are 
 
 ![kubernetes-dashboard](./assets/diagrams/deployment/kubernetesDashboard.png)
 
-### 4. Helm 
+### 4. Helm
 
 Please review [Mojaloop Helm Chart](../repositories/helm.md) to understand the relationships between the deployed Mojaloop helm charts.
 
@@ -181,17 +181,17 @@ Please review [Mojaloop Helm Chart](../repositories/helm.md) to understand the r
    ```bash
    helm --namespace demo --name moja install mojaloop/mojaloop
    ```
-   
+
    Version specific installation:
    ```bash
    helm --namespace demo --name moja install mojaloop/mojaloop --version {version}
    ```
-   
+
    List of available versions:
    ```bash
    helm search -l mojaloop/mojaloop
    ```
-   
+
    Custom configured installation:
    ```bash
    helm --namespace demo --name moja install mojaloop/mojaloop -f {custom-values.yaml}
@@ -203,33 +203,33 @@ Please review [Mojaloop Helm Chart](../repositories/helm.md) to understand the r
 1. Update your /ect/hosts for local deployment:
 
    _Note: This is only applicable for local deployments, and is not needed if custom DNS or ingress rules are configured in a customized [values.yaml](https://github.com/mojaloop/helm/blob/master/mojaloop/values.yaml)_.
-   
+
    ```bash
    vi /etc/hosts
    ```
    _Windows the file can be updated in notepad - need to open with Administrative privileges. File location `C:\Windows\System32\drivers\etc\hosts`_.
-   
+
    Include the following lines (_or alternatively combine them_) to the host config.
 
    The below required config is applicable to Helm release >= versions 6.2.2 for Mojaloop API Services;
    ```text
    127.0.0.1       central-ledger.local central-settlement.local ml-api-adapter.local account-lookup-service.local account-lookup-service-admin.local quoting-service.local moja-simulator.local central-ledger central-settlement ml-api-adapter account-lookup-service account-lookup-service-admin quoting-service simulator host.docker.internal
    ```
-      
+
    The below optional config is applicable to Helm release >= versions 6.2.2 for Internal components, please include the following in the host configuration.
    ```text
    127.0.0.1       forensic-logging-sidecar.local central-kms.local central-event-processor.local email-notifier.local
    ```
-      
+
    For Helm legacy releases prior to versions 6.2.2, please include the following in the host configuration.
    ```text
    127.0.0.1       interop-switch.local central-end-user-registry.local central-directory.local central-hub.local
    ```
-   
+
 2. Test system health in your browser after installation. This will only work if you have an active helm chart deployment running.
-   
+
    _Note: The examples below are only applicable to a local deployment. The entries should match the DNS values or ingress rules as configured in the [values.yaml](https://github.com/mojaloop/helm/blob/master/mojaloop/values.yaml) or otherwise matching any custom ingress rules configured_.
-   
+
    **ml-api-adapter** health test:
    ```
    http://ml-api-adapter.local/health
@@ -238,7 +238,7 @@ Please review [Mojaloop Helm Chart](../repositories/helm.md) to understand the r
    **central-ledger** health test:
    ```
    http://central-ledger.local/health
-   ``` 
+   ```
 
 ### 6. Postman
 
@@ -251,7 +251,7 @@ Please, follow these instructions: [Get Postman](https://www.getpostman.com/post
 #### 6.2. Setup Postman
 
 Grab the latest collections & environment files from [Mojaloop Postman Github repo](https://github.com/mojaloop/postman): [https://github.com/mojaloop/postman](https://github.com/mojaloop/postman)
- 
+
 After an initial setup or new deployment, the [OSS New Deployment FSP Setup section](../contributors-guide/tools-and-technologies/automated-testing.md) needs to be completed. This will seed the Database with the required enumerations and static data to enable the sucessful execution of any manual or automation tests by the other collections.
 
-Refer to the [QA and Regression Testing in Mojaloop](../contributors-guide/tools-and-technologies/automated-testing.md) documentation for more complete information to complement your testing requirements. 
+Refer to the [QA and Regression Testing in Mojaloop](../contributors-guide/tools-and-technologies/automated-testing.md) documentation for more complete information to complement your testing requirements.

--- a/deployment-guide/README.md
+++ b/deployment-guide/README.md
@@ -93,9 +93,9 @@ Insure **kubectl** is installed. A complete set of installation instruction are 
    kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
    ```
 
-   If you have installed MicroK8s, **enable the MicroK8s** dashboard;
+   If you have installed MicroK8s, **enable the MicroK8s** dashboard and other required extensions;
    ```bash
-   microk8s.enable dashboard
+   microk8s.enable dashboard storage ingress dns istio
    ```
    **Remember** to prefix all **kubectl** commands with **microk8s** if you opted not to create an alias.
 

--- a/deployment-guide/local-setup-linux.md
+++ b/deployment-guide/local-setup-linux.md
@@ -24,16 +24,17 @@ This environment setup was validated on:
 
 Kubernetes installation for a local environment.
 
-#### 2.1. MicroK8S
+### 2.1. MicroK8S
 
-We recommend install directly from the snap store.
+We recommend installing directly from the snap store.
 
 Don't have the snap command? [Install snapd first](https://snapcraft.io/docs/core/install).
 
 1. Installing MicroK8s from snap.
    ```bash
-   snap install microk8s --classic
+   snap install microk8s --classic --channel=1.13/stable
    ```
+   MicroK8s 1.14 release and onward have replaced dockerd with contanerd.
 
 2. Verify MicroK8s is installed and available.
    ```bash
@@ -51,7 +52,7 @@ Don't have the snap command? [Install snapd first](https://snapcraft.io/docs/cor
    ```
 
 5. This step is only necessary if you require **microk8s.kubectl** to function as a standard **kubectl** command. This **DOES NOT** mean that you can then use **kubectl** to access **OTHER** k8s clusters.
-   
+
    An example of why you would use this: You have a bash script or 3rd party tool that expects **kubectl** to be available. E.g. If you want to use Helm, it will not work against **microk8s.kubectl**, thus one **MUST** setup the alias for Helm to function correctly.
    ```bash
    snap alias microk8s.kubectl kubectl
@@ -79,9 +80,21 @@ Don't have the snap command? [Install snapd first](https://snapcraft.io/docs/cor
    microk8s.kubectl config use-context microk8s
    ```
 
-### 1.2. Docker
+### 2.2. Helm
 
-Docker is deployed as part of the MicroK8s installation. The docker daemon used by MicroK8s is listening on unix:///var/snap/microk8s/current/docker.sock. You can access it with the **microk8s.docker** command.
+We recommend installing directly from the snap store.
+
+Don't have the snap command? [Install snapd first](https://snapcraft.io/docs/core/install).
+
+1. Installing Helm from snap.
+   ```bash
+   snap install helm --channel=2.16/stable
+   ```
+   Helm version >2.16 does not support `helm init` used in the deployment guide.
+
+### 2.3. Docker
+
+Docker is deployed as part of the MicroK8s 1.13 installation. The docker daemon used by MicroK8s is listening on unix:///var/snap/microk8s/current/docker.sock. You can access it with the **microk8s.docker** command.
 
 1. If you require **microk8s.docker** to function as a standard **docker** command, you set an alias.
    ```bash
@@ -100,7 +113,7 @@ Docker is deployed as part of the MicroK8s installation. The docker daemon used 
 
 3. Continue setup and configuration from the Kubernetes Dashboard section in the [Mojaloop's deployment guide](./README.md#31-kubernetes-dashboard) document.
 
-## 2. Useful Tips
+## 3. Useful Tips
 
 1. Resolve problems with VSCode and kafka on ubuntu 18.04. To make the code work with VSCode debugger, added the following into the launch.json
     ```json

--- a/deployment-guide/local-setup-linux.md
+++ b/deployment-guide/local-setup-linux.md
@@ -90,7 +90,7 @@ Don't have the snap command? [Install snapd first](https://snapcraft.io/docs/cor
    ```bash
    snap install helm --channel=2.16/stable
    ```
-   Helm version >2.16 does not support `helm init` used in the deployment guide.
+   Helm version >2.16 does not support `helm init` and Tiller used in the deployment guide.
 
 ### 2.3. Docker
 


### PR DESCRIPTION
MicroK8S 1.14 and onward does not ship with docker built in.
Using >1.13 will error out when trying to install Kubernetes Dashboard.
Updated the documentation to point at last release which ships with docker, 1.13.

https://github.com/ubuntu/microk8s/issues/382#issuecomment-476729624
https://github.com/helm/helm/issues/6996#issuecomment-555010868

NOTE: My insights gained from setting up the local deployment conflicts with information found in the troubleshooting guide.
The guide recommends --channel=1.15/stable but 1.15 shouldn't work.
If anyone has insight on this matter please correct me.

I also am unsure to whether this info should live in the setup or troubleshooting.
While troubleshooting is more relevant I could have saved a lot of time if it was in local setup on my first pass.