### PR TITLE
Corrected typo "Moajoop" => "Mojaloop" in decimal.md and gitbook index.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -135,7 +135,7 @@
 * [Mojaloop Publications](mojaloop-publications.md)
 * [Discussion Documents](discussions/readme.md)
   * [ISO integration Overivew](discussions/ISO_Integration.md)
-  * [Moajoop Decimal Type; Based on XML Schema Decimal Type](discussions/decimal.md)
+  * [Mojaloop Decimal Type; Based on XML Schema Decimal Type](discussions/decimal.md)
   * [Workbench Workstream](discussions/workbench.md)
   * [Cross Border Meeting Notes Day 1](discussions/cross_border_day_1.md)
   * [Cross Border Meeting Notes Day 2](discussions/cross_border_day_2.md)

--- a/discussions/decimal.md
+++ b/discussions/decimal.md
@@ -1,4 +1,4 @@
-# Moajoop Decimal Type; Based on XML Schema Decimal Type
+# Mojaloop Decimal Type; Based on XML Schema Decimal Type
 
 ## Decimal value type
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentation",
-  "version": "9.6.0",
+  "version": "10.1.0",
   "description": "Mojaloop Documentation GitBook Project",
   "dependencies": {
     "express": "4.17.1",


### PR DESCRIPTION
- "Moajoop" => "Mojaloop" in decimal.md.
- gitbook index reference "Moajoop" => "Mojaloop".
- Updated version to 10.1.0.