### PR TITLE
Updated mojaloop helm repo from http to https

### DIFF
--- a/deployment-guide/README.md
+++ b/deployment-guide/README.md
@@ -152,7 +152,7 @@ Refer to the [Helm v2 to v3 Migration Guide](./helm-legacy-migration.md) if you 
 
 1. Add mojaloop repo to your Helm config:
    ```bash
-   helm repo add mojaloop http://mojaloop.io/helm/repo/
+   helm repo add mojaloop https://mojaloop.io/helm/repo/
    ```
    If the repo already exists, substitute 'add' with 'apply' in the above command.
 


### PR DESCRIPTION
Both HTTP and HTTPS are available for the Mojaloop Helm repo, so let's recommend everyone uses the HTTPS option.