### PR TITLE
Proposing Naming Convention standards

### DIFF
--- a/contributors-guide/standards/README.md
+++ b/contributors-guide/standards/README.md
@@ -10,6 +10,18 @@ These style guides are chosen because they can be easily enforced and checked us
 
 The goal of these guides is to ensure an easy developer workflow and reduce code commits that contain changes for the sake of style over content. By reducing the noise in diffs we make the job of reviewers easier. 
 
+
+### Naming Conventions
+
+To avoid confusion and guarantee cross-language interoperation, follow these rules regarding naming conventions:
+- Do not use abbreviations or contractions as parts of identifier names. For example, use `SettlementWindow` instead of `SetWin`.
+- Do not use acronyms that are not generally accepted in the computing field.
+- Where appropriate, use well-known acronyms to replace lengthy phrase names. For example, use `UI` for `User Interface`.
+- Use Pascal case or camel case for names more than two characters long depending on context (e.g. class names vs variable names). For example, use `SettlementWindow` (Class) or `settlementWindow` (Variable). However, you should capitalize abbreviations that consist of only two characters, such as `ID` instead of `Id`.
+- Avoid abbreviations in identifiers or parameter names. If you must use abbreviations, use camel case for abbreviations that consist of more than two characters, even if this contradicts the standard abbreviation of the word.
+
+Ref: [Microsoft - Design Guidelines for Class Library Developers](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/141e06ef(v=vs.71)?redirectedfrom=MSDN)
+
 ### Code Style
 
 #### Javascript


### PR DESCRIPTION
Its widely accepted that camel case is used as a standard naming convention through-out Mojaloop's code-base, but there are edge scenarios that require further clarification that this PR tries to address.

Credit to @vijayg10 for the suggested convention.