### PR TITLE
feat: enable edit on github link

### DIFF
--- a/vuepress/docs/.vuepress/config.js
+++ b/vuepress/docs/.vuepress/config.js
@@ -30,9 +30,11 @@ module.exports = {
    * ref：https://v1.vuepress.vuejs.org/theme/default-theme-config.html
    */
   themeConfig: {
-    repo: '',
-    editLinks: false,
-    docsDir: '',
+    repo: 'https://github.com/mojaloop/documentation/',
+    // TODO: change this to master once we have merged in the new docs!
+    docsBranch: 'mojaloop-docs-2.0',
+    editLinks: true,
+    docsDir: 'vuepress/docs',
     editLinkText: 'Edit this page on GitHub',
     smoothScroll: true,
     logo: '/mojaloop_logo_med.png',


### PR DESCRIPTION
Enables the "edit on github" link on the bottom of pages. 

Notes:
- We will need to update the branch to `master` when we do the merge back in.
- I noticed that I had to select the "next" version of the documentation link to work, and not get a 404 when redirecting to GitHub. So perhaps we should find a way to disable the edit button when users are browsing previous versions of the documentation.
 