### PR TITLE
chore: updated links onFSPIOP API docs

### DIFF
--- a/vuepress/docs/api/fspiop/json-binding-rules.md
+++ b/vuepress/docs/api/fspiop/json-binding-rules.md
@@ -40,37 +40,39 @@ The types used in the PDP API fall primarily into three categories:
 
 The various types used in _API Definition_, _Data Model_ and the _Open API Specification_, as well as the JSON transformation rules to which their instances must adhere, are identified in the following sections.
 
+<br />
+
 ### Open API for FSP Interoperability Specification
 
 The Open API for FSP Interoperability Specification includes the following documents.
 
-#### General Documents
-
-- _Glossary_
-
 #### Logical Documents
 
-- _Logical Data Model_
+- [Logical Data Model](./logical-data-model)
 
-- _Generic Transaction Patterns_
+- [Generic Transaction Patterns](./generic-transaction-patterns)
 
-- _Use Cases_
+- [Use Cases](./use-cases)
 
 #### Asynchronous REST Binding Documents
 
-- _API Definition_
+- [API Definition](./api-definition)
 
-- _JSON Binding Rules_
+- [JSON Binding Rules](#)
 
-- _Scheme Rules_
+- [Scheme Rules](./scheme-rules)
 
 #### Data Integrity, Confidentiality, and Non-Repudiation
 
-- _PKI Best Practices_
+- [PKI Best Practices](./pki-best-practices)
 
-- _Signature_
+- [Signature](./v1.1/signature)
 
-- _Encryption_
+- [Encryption](./v1.1/encryption)
+
+#### General Documents
+
+- [Glossary](./glossary)
 
 <br />
 

--- a/vuepress/docs/api/fspiop/pki-best-practices.md
+++ b/vuepress/docs/api/fspiop/pki-best-practices.md
@@ -35,37 +35,39 @@ For more information about the environment, see [Network Topology](#network-topo
 
 Communication between platforms is performed using a REST (REpresentational State Transfer)-based HTTP protocol (for more information, see _API Definition_). Because this protocol does not provide a means for ensuring either integrity or confidentiality between platforms, extra security layers must be added to protect sensitive information from alteration or exposure to unauthorized parties.
 
+<br />
+
 ### Open API for FSP Interoperability Specification
 
 The Open API for FSP Interoperability Specification includes the following documents.
 
-#### General Documents
-
-- _Glossary_
-
 #### Logical Documents
 
-- _Logical Data Model_
+- [Logical Data Model](./logical-data-model)
 
-- _Generic Transaction Patterns_
+- [Generic Transaction Patterns](./generic-transaction-patterns)
 
-- _Use Cases_
+- [Use Cases](./use-cases)
 
 #### Asynchronous REST Binding Documents
 
-- _API Definition_
+- [API Definition](./api-definition)
 
-- _JSON Binding Rules_
+- [JSON Binding Rules](./json-binding-rules)
 
-- _Scheme Rules_
+- [Scheme Rules](./scheme-rules)
 
 #### Data Integrity, Confidentiality, and Non-Repudiation
 
-- _PKI Best Practices_
+- [PKI Best Practices](#)
 
-- _Signature_
+- [Signature](./v1.1/signature)
 
-- _Encryption_
+- [Encryption](./v1.1/encryption)
+
+#### General Documents
+
+- [Glossary](./glossary)
 
 <br />
 

--- a/vuepress/docs/api/fspiop/scheme-rules.md
+++ b/vuepress/docs/api/fspiop/scheme-rules.md
@@ -41,37 +41,39 @@ This document defines scheme rules for Open API for FSP Interoperability (hereaf
 
     a. Security and non-functional scheme rules should be determined and identified in the implementation policy of a scheme. 
 
+<br />
+
 ### Open API for FSP Interoperability Specification
 
 The Open API for FSP Interoperability Specification includes the following documents.
 
-#### General Documents
-
-- _Glossary_
-
 #### Logical Documents
 
-- _Logical Data Model_
+- [Logical Data Model](./logical-data-model)
 
-- _Generic Transaction Patterns_
+- [Generic Transaction Patterns](./generic-transaction-patterns)
 
-- _Use Cases_
+- [Use Cases](./use-cases)
 
 #### Asynchronous REST Binding Documents
 
-- _API Definition_
+- [API Definition](./api-definition)
 
-- _JSON Binding Rules_
+- [JSON Binding Rules](./json-binding-rules)
 
-- _Scheme Rules_
+- [Scheme Rules](#)
 
 #### Data Integrity, Confidentiality, and Non-Repudiation
 
-- _PKI Best Practices_
+- [PKI Best Practices](./pki-best-practices)
 
-- _Signature_
+- [Signature](./v1.1/signature)
 
-- _Encryption_
+- [Encryption](./v1.1/encryption)
+
+#### General Documents
+
+- [Glossary](./glossary)
 
 <br />
 

--- a/vuepress/docs/api/fspiop/v1.1/encryption.md
+++ b/vuepress/docs/api/fspiop/v1.1/encryption.md
@@ -37,6 +37,40 @@ To support encryption for multiple fields of an API message, JWE is extended in 
 
 <br />
 
+### Open API for FSP Interoperability Specification
+
+The Open API for FSP Interoperability Specification includes the following documents.
+
+#### Logical Documents
+
+- [Logical Data Model](./logical-data-model)
+
+- [Generic Transaction Patterns](./generic-transaction-patterns)
+
+- [Use Cases](./use-cases)
+
+#### Asynchronous REST Binding Documents
+
+- [API Definition](./api-definition)
+
+- [JSON Binding Rules](../json-binding-rules)
+
+- [Scheme Rules](./scheme-rules)
+
+#### Data Integrity, Confidentiality, and Non-Repudiation
+
+- [PKI Best Practices](./pki-best-practices)
+
+- [Signature](./v1.1/signature)
+
+- [Encryption](#)
+
+#### General Documents
+
+- [Glossary](./glossary)
+
+<br />
+
 ## API Encryption Definition
 
 This section introduces the technology used by API encryption, including:

--- a/vuepress/docs/api/fspiop/v1.1/signature.md
+++ b/vuepress/docs/api/fspiop/v1.1/signature.md
@@ -44,6 +44,40 @@ Because intermediary fees are not supported in the current version of the API, i
 
 <br />
 
+### Open API for FSP Interoperability Specification
+
+The Open API for FSP Interoperability Specification includes the following documents.
+
+#### Logical Documents
+
+- [Logical Data Model](./logical-data-model)
+
+- [Generic Transaction Patterns](./generic-transaction-patterns)
+
+- [Use Cases](./use-cases)
+
+#### Asynchronous REST Binding Documents
+
+- [API Definition](./definitions)
+
+- [JSON Binding Rules](./json-binding-rules)
+
+- [Scheme Rules](./scheme-rules)
+
+#### Data Integrity, Confidentiality, and Non-Repudiation
+
+- [PKI Best Practices](./pki-best-practices)
+
+- [Signature](#)
+
+- [Encryption](./v1.1/encryption)
+
+#### General Documents
+
+- [Glossary](../glossary)
+
+<br />
+
 ## API Signature Definition
 
 This section introduces the technology used by the API signature, including the data exchange format for the signature of an API message and the mechanism used to generate and verify a signature.


### PR DESCRIPTION
- Updated links on all FFSPIOP API specification docs.
- Added missing `Open API for FSP Interoperability Specification` section on `Encryption`  and `Signature` docs.
- Updated  `Open API for FSP Interoperability Specification` section to point to links for `JSON Binding Rules`, `Scheme Rules` and `PKI Best Practices` docs.