### PR TITLE
feat(infra): add /helm/ path to cloudfront

### DIFF
--- a/infra/src/cloudfront.tf
+++ b/infra/src/cloudfront.tf
@@ -135,6 +135,20 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
       }
     }
   }
+  ordered_cache_behavior {
+    path_pattern = "/helm/*"
+    target_origin_id = "mojaloop.github.io"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
 
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]


### PR DESCRIPTION
For some reason, `https://mojaloop.io/helm/repo/` redirects to `https://docs.mojaloop.io/helm/repo` which is now broken because of the docs updates.

This change adds the necessary cloudfront config to point that link to where the charts are published on github pages