### PR TITLE
chore: adding pr template 

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,14 @@
+
+
+### Brief description of changes included
+
+### A reference to a related GitHub issue (from project repo, preferably)
+
+### Checklist before requesting a review
+- [ ] Changes follow approved designs, architecture (for code changes)
+- [ ] Added tests to cover new features
+- [ ] Documentation updated, if applicable
+
+@mentions of the person or team responsible for reviewing proposed changes, or contributors involved.
+
+For PR titles, please refer to the adopted standard [here](https://docs.mojaloop.io/community/standards/creating-new-features.html#open-a-pull-request-pr).


### PR DESCRIPTION
Adding a PR template for contributions.

Will test on a few repos and include for all official repos after initial feedback is taken.

No design changes included. Maintenance change