### PR TITLE
docs: pre-release branches

### DIFF
--- a/docs/community/standards/creating-new-features.md
+++ b/docs/community/standards/creating-new-features.md
@@ -35,11 +35,88 @@ Create a new branch from the `master` branch with the following format: `<branch
 Where `<branchType>` can be one of the following:
 
 | branchType | Description |
-| :--- | :--- |
-| feature | Any new or maintenance features that are in active development. |
-| hotfix | A hotfix branch is for any urgent fixes. |
-| release | A release branch containing a snapshot of a release. |
-| backup | A temporary backup branch. Used normally during repo maintenance. |
+| :---       | :--- |
+| hotfix     | A `hotfix` branch is for any urgent fixes. |
+| feature    | A `development` branch for new or maintenance features that are in active development. |
+| fix        | A `development` branch that is used to fix a bug. |
+| release    | A release branch containing a snapshot of a release. |
+| backup     | A temporary backup branch. Used normally during repo maintenance. |
+| major      | A `pre-release` branch for major changes. |
+| minor      | A `pre-release` branch for minor changes. |
+| patch      | A `pre-release` branch for patch changes. |
+
+## Main branch
+
+The main branch must always contain code that is suitable for deployment.
+Build automation tools will try to build and test code from this branch and
+tag this branch with semver based version tags on success. The resulting
+artifacts will be also published on respective repositories (npm, docker, etc.),
+so that they can be used by other modules.
+
+## Hotfix branches
+
+These branches are created from a tag on main branch, when the corresponding
+version has been deployed in production and an issue must be fixed and at the
+same time main branch has newer published versions or undergoing development,
+where this fix cannot be included in a timely and stable way. These branches are
+named by using the pattern `hotfix/<issue#><issueDescription>`. It is highly
+recommended that the fix be first committed in main (or another branch that is
+going to be merged to main) and then cherry-picked in the hotfix branch. Hot-fix
+branches are usually not merged to main and not deleted, as they may be used
+for subsequent fixes. On hot-fix branches build automation tools will create
+tags and publish corresponding packages by increasing only the patch version number.
+
+## Prerelease branches
+
+Prerelease branches are used when the development process requires artifacts
+to be available in the repository for either automated or manual testing of
+in-progress features or fixes, that are not ready for a release.
+These branches are used to avoid the manual work associated with publishing
+in repositories. The published artifacts will have prerelease versions and tags,
+as specified by semver. Build automation tools will create and publish these
+prerelease versions in the package repository and tag the branch in the git
+repository for each commit that is successfully built. Prerelease branches are
+usually created from the main branch and later merged into it. The patterns
+for prerelease branches are:
+
+- `major/<issue#><issueDescription>` - when a branch is expected to include
+  breaking changes.
+- `minor/<issue#><issueDescription>` - when a branch is expected to include
+  only new features and no breaking changes. This is the most common kind of
+  branch, where all new development happens.
+- `patch/<issue#><issueDescription>` - when a branch is expected to include
+  only fixes and no new features or breaking changes. These can sometimes be
+  created from hotfix branches, when fixes need to be first published for tests,
+  before being merged in the hotfix branch.
+
+The build scripts will automatically publish a prerelease version and tag using
+`<issue#><issueDescription>` as the prerelease identifier, followed by a
+sequential number, i.e. something like
+`X.Y.Z-<issue#><issueDescription>.sequence`, where X, Y or Z will be auto
+increment once for the first build of the branch, depending on the
+major/minor/patch prefix of the branch name and `sequence` will be incremented
+on each successful build. For the prerelease branches it is important to ensure
+`<issue#><issueDescription>` complies with the prerelease identifier rules
+specified by semver. Sometimes a minor prerelease branch can eventually
+include a breaking change, in which case the developers must ensure that
+there is no parallel active development happening on another major
+branch, as this may end up with both branches trying to release the same major
+version. In general, developers should be careful when multiple prerelease
+branches are being developed and ensure the version being released in the end
+does not conflict with other prerelease branches. In such cases a manual edit
+of the version may be needed while resolving a merge conflict for the version property.
+
+## Development branches
+
+These branches are used primarily for development of new features, when no
+artifacts need to be published to package repositories until the branch is
+merged. They are created from the main or prerelease branches. Names of these
+branches must not match any of the patterns described above. The frequently
+used ones are `feature/<issue#><issueDescription>` or
+`fix/<issue#><issueDescription>`. Development branches can later
+be renamed to prerelease ones, if the development process requires it. Using a
+development branch instead of a prerelease branch helps avoid excessive
+publishing of artifacts and tags, which take more time and clutter the repository.
 
 ## Working on your Feature
 
@@ -116,8 +193,8 @@ Mojaloop uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0
 
 By adopting Conventional Commits + Semantic Versioning we can automatically release a new version for a given component and increment the `MAJOR`, `MINOR` and `BUGFIX` versions based soley on the PR titles, and auto generate rich changelogs. (See [this example](https://github.com/mojaloop/thirdparty-scheme-adapter/releases/tag/v11.20.0) of an auto generated changelog)
 
-> **Note**:  
-> When merging (and squashing) a PR, GitHub uses the *title* of the PR for the git commit message. This means that to specify a breaking change, you must use the `!` format:  
+> **Note**:
+> When merging (and squashing) a PR, GitHub uses the *title* of the PR for the git commit message. This means that to specify a breaking change, you must use the `!` format:
 > "If included in the type/scope prefix, breaking changes MUST be indicated by a ! immediately before the :. If ! is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change."
 
 #### Examples of good PR titles


### PR DESCRIPTION
This PR includes more details about branching and also is a proposal to introduce pre-release patterns for branches that will allow us to automate further the development process. Currently automation for publishing of pre-release versions is only available for a limited pattern `-snapshot.x`, which creates conflicts when multiple features or fixes need to be developed in isolation and pre-released for testing. As many of these features or fixes will branch from the same commit in main, they end up having the same snapshot versions/tags. The proposal is to have arbitrary names of these prereleases and trigger the publishing based on the branch name, instead of the tag name, while the tag naming will be automated.