### PR TITLE
docs: add change history and Mojaloop version details to Product documentation

### DIFF
--- a/docs/product/features/CrossBorder.md
+++ b/docs/product/features/CrossBorder.md
@@ -14,3 +14,12 @@ This model can be extended further, so that countries with existing domestic ins
 
 ![Interconnecting Domestic Schemes to Offer Cross Border transactions](./ComplexXB.svg)
 
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|22nd April 2025| Paul Makin|Added version history; clarified some wording|
+|1.0|14th April 2025| Paul Makin|Initial version|

--- a/docs/product/features/CrossBorder.md
+++ b/docs/product/features/CrossBorder.md
@@ -16,7 +16,7 @@ This model can be extended further, so that countries with existing domestic ins
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/ForeignExchange.md
+++ b/docs/product/features/ForeignExchange.md
@@ -39,3 +39,13 @@ Other, more complex business models will be supported in an upcoming release. Th
 5. DFSP 2 proposes the transaction to multiple FXPs, selects the one with the most beneficial terms and sends 10 X to that FXP, who returns the equivalent value in currency Y back to DFSP 2, who then pays out to the payee (less fees, currency spread, etc). 
 
 The following page will be of interest to those who wish to review how interscheme and foreign exchange capabilities relate to  [**cross border transactions**](./CrossBorder.md).
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|22nd April 2025| Paul Makin|Added version history|
+|1.0|13th March 2025| Paul Makin|Initial version|

--- a/docs/product/features/ForeignExchange.md
+++ b/docs/product/features/ForeignExchange.md
@@ -42,7 +42,7 @@ The following page will be of interest to those who wish to review how intersche
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/InterconnectingSchemes.md
+++ b/docs/product/features/InterconnectingSchemes.md
@@ -1,6 +1,6 @@
 # Interconnecting Payment Schemes
 
-Mojaloop, as a single deployment, is intended to be used to operate one (or more) payment schemes, operating on a single platform. Of course, it is quite common for a country to host multiple payment schemes, built around differing requirements for different sectors. 
+Mojaloop, as a single deployment, is intended to be used to operate one (or more) payment schemes, operating on a single platform. Of course, it is quite common for a country to host multiple payment schemes operating on separate platforms, built around differing requirements for different sectors. 
 
 Ultimately, though, as a payment scheme grows, then the need to be interconnected  or interoperable with other payment schemes in a country grows. Mojaloop accommodates this, through a mechanism we call "Interscheme".
 
@@ -20,3 +20,13 @@ The current version of Mojaloop only supports the interconnection of Mojaloop-ba
 Further details of the implementation of this scheme interconnection capability can be found in the [**interscheme documentation**](./interscheme.md).
 
 The following pages will be of interest to those who wish to review how interscheme capabilities relate to [**foreign exchange**](./ForeignExchange.md) and [**cross border transactions**](./CrossBorder.md).
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|22nd April 2025| Paul Makin|Added version history; clarified some wording|
+|1.0|14th April 2025| Paul Makin|Initial version|

--- a/docs/product/features/InterconnectingSchemes.md
+++ b/docs/product/features/InterconnectingSchemes.md
@@ -23,7 +23,7 @@ The following pages will be of interest to those who wish to review how intersch
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/connectivity.md
+++ b/docs/product/features/connectivity.md
@@ -20,3 +20,13 @@ This toolkit is complemented by three exemplar implementations, ready for custom
 All DFSPs should be aware that reaping the benefits of an inclusive instant payments solution such as Mojaloop relies on the implementation of a “whole ecosystem” approach - and this means extending the reach of the Mojaloop service into the DFSPs’ domains, giving them and their customers the advantages of assurance of transaction finality, lower cost and the reliable delivery of every valid transaction.
 
 Note that the adoption of an exemplar installation affects the type of service a DFSP can provide to their customers. The Premium option is suitable for DFSPs with high throughout and reliability requirements, the Enhanced option places some limits on throughput and availability and may be best suited to medium or small DFSPs, and the Standard option places strict limits on throughput and availability and removes the ability to initiate bulk payments, and so may only be suitable for small DFSPs.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|14th April 2025| Paul Makin|Updates related to the release of V17|
+|1.0|5th February 2025| Paul Makin|Initial version|

--- a/docs/product/features/connectivity.md
+++ b/docs/product/features/connectivity.md
@@ -23,7 +23,7 @@ Note that the adoption of an exemplar installation affects the type of service a
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/engineering.md
+++ b/docs/product/features/engineering.md
@@ -80,7 +80,7 @@ the default.
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/engineering.md
+++ b/docs/product/features/engineering.md
@@ -10,8 +10,7 @@ the default.
 
 ## Transfers
 
-1.  Resource identifiers are unique within a scheme and enforced by the
-    hub.
+1.  Resource identifiers are unique within a scheme and enforced by the hub.
 
 2.  API methods which can potentially return large result sets are paged
     by default.
@@ -78,3 +77,13 @@ the default.
     wherever possible.
 
 7.  Aggregates are stateless.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|14th April 2025| Paul Makin|Added version control|
+|1.0|5th February 2025| James Bush|Initial version|

--- a/docs/product/features/invariants.md
+++ b/docs/product/features/invariants.md
@@ -351,7 +351,7 @@ failures.**
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/invariants.md
+++ b/docs/product/features/invariants.md
@@ -1,7 +1,3 @@
-**14th April 2025**\
-Author: James Bush\
-Version: 1.0\
-
 # Invariants
 
 ## General Principles
@@ -352,3 +348,13 @@ failures.**
 9.  Participants need timely confidence in the status of financial
     transactions across the scheme in order to minimise exposure risk
     and deliver excellent customer experiences.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|14th April 2025| Paul Makin|Added version control|
+|1.0|5th February 2025| James Bush|Initial version|

--- a/docs/product/features/ml-feature-list.md
+++ b/docs/product/features/ml-feature-list.md
@@ -65,7 +65,7 @@ Mojaloop, without exception, and they pass the standard set of Mojaloop tests.
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/ml-feature-list.md
+++ b/docs/product/features/ml-feature-list.md
@@ -1,7 +1,3 @@
-**14th April 2025**\
-Author: Paul Makin\
-Version: 1.2
-
 # About Mojaloop 
 
 Mojaloop is open source instant payments software that interconnects
@@ -61,19 +57,17 @@ of Mojaloop:
 ## Purpose of This Document
 
 This document catalogues the features of Mojaloop, independent of
-implementation. It is intended to both inform potential adopters of the
-features they can expect and (where appropriate) how those features can
-be expected to function, and to inform developers of the features they
-must implement in order for their efforts to be accepted as an official
-instance of Mojaloop.
+implementation. It is intended to both inform potential adopters of the features they can expect and (where appropriate) how those features can be expected to function, and to inform developers of the features they must implement in order for their efforts to be accepted as an official instance of Mojaloop.
 
 The Mojaloop Foundation (MLF) defines an implementation as being an
 official instance of Mojaloop if it implements all of the features of
-Mojaloop, without exception, and they pass the standard set of Mojaloop
-tests.
+Mojaloop, without exception, and they pass the standard set of Mojaloop tests.
 
-## Scope
+## Applicability
 
-This feature list is subject to amendment as the Mojaloop ecosystem
-continues to develop. Currently, it relates to Mojaloop Congo, Version 16.
+This version of this document relates to Mojaloop Version 17.
 
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.2|14th April 2025| Paul Makin|Updates related to the release of V17|

--- a/docs/product/features/product.md
+++ b/docs/product/features/product.md
@@ -202,7 +202,7 @@ This includes the reports relating to settlement.
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/product.md
+++ b/docs/product/features/product.md
@@ -199,3 +199,13 @@ those reports into any of the operator portals, allowing the reports to
 be generated as required by operations staff.
 
 This includes the reports relating to settlement.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|14th April 2025| Paul Makin|Updates related to the release of V17|
+|1.0|5th February 2025| Paul Makin|Initial version|

--- a/docs/product/features/risk.md
+++ b/docs/product/features/risk.md
@@ -43,3 +43,12 @@ applied are:
     The NDC is used in tandem with the liquidity balance in the
     authorisation of transactions during the Quotation phase.
     
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.1|14th April 2025| Paul Makin|Updates related to the release of V17|
+|1.0|13th March 2025| Paul Makin|Initial version|

--- a/docs/product/features/risk.md
+++ b/docs/product/features/risk.md
@@ -45,7 +45,7 @@ applied are:
     
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/transaction.md
+++ b/docs/product/features/transaction.md
@@ -104,7 +104,7 @@ other payment clearing hubs. What differentiates Mojaloop is:
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|

--- a/docs/product/features/transaction.md
+++ b/docs/product/features/transaction.md
@@ -100,10 +100,13 @@ other payment clearing hubs. What differentiates Mojaloop is:
 
 	The Mojaloop community provides a number of tools that can be freely used by DFSPs to connect to a Mojaloop Hub. These remain within the DFSP's domain, and are not the concern of the hub operator or any other party. As well as managing the connection to the Hub and facilitating transactions, these tools also ensure the security of the connection and in particular provide the key DFSP link to this non-repudiation capability.  
 	&nbsp;
-4.  **The PISP API is made available through the Mojaloop Hub,** not by
-    individual Participants. Consequently a fintech can integrate with
-    the Hub and immediately be connected to all connected DFSPs, rather
-    than needing to complete an API integration with the all
-    individually. This substantially reduces costs and increases
-    reliability for fintechs and their customers.
-    
+4.  **The PISP API is made available through the Mojaloop Hub,** not by individual Participants. Consequently a fintech can integrate with the Hub and immediately be connected to all connected DFSPs, rather than needing to complete an API integration with the all individually. This substantially reduces costs and increases reliability for fintechs and their customers.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.2|14th April 2025| Paul Makin|Updates related to the release of V17|

--- a/docs/product/features/use-cases.md
+++ b/docs/product/features/use-cases.md
@@ -71,3 +71,12 @@ are layered over the top of the standard use cases.
 These
 scheme-specific use cases can readily be added by individual scheme
 operators.
+
+## Applicability
+
+This version of this document relates to Mojaloop Version 17.
+
+## Document History
+  |Version|Date|Author|Detail|
+|:--------------:|:--------------:|:--------------:|:--------------:|
+|1.2|14th April 2025| Paul Makin|Updates related to the release of V17, including links to the interscheme and FX documentation.|

--- a/docs/product/features/use-cases.md
+++ b/docs/product/features/use-cases.md
@@ -74,7 +74,7 @@ operators.
 
 ## Applicability
 
-This version of this document relates to Mojaloop Version 17.
+This version of this document relates to Mojaloop Version [17.0.0](https://github.com/mojaloop/helm/releases/tag/v17.0.0)
 
 ## Document History
   |Version|Date|Author|Detail|


### PR DESCRIPTION
Updated the Product docs to include a version history (at the bottom), and an indication of the version of Mojaloop they apply to.