### PR TITLE
fix: don't run main workflow on the schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,9 @@ jobs:
 workflows:
   version: 2
   build_and_test:
+    when:
+      not:
+        equal: [ scheduled, << pipeline.trigger_source >> ]
     jobs:
       - build:
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,8 +390,7 @@ workflows:
 
   scheduled_cleanup:
     when:
-      and:
-        - equal: [ scheduled, << pipeline.trigger_source >> ]
+      equal: [ scheduled, << pipeline.trigger_source >> ]
     jobs:
       - cleanup_pr_preview:
           context: org-global


### PR DESCRIPTION
Should prevent circleci from running the build_and_test workflow on the schedule.