### PR TITLE
fix(ci): improve PR cleanup script 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,34 +284,33 @@ jobs:
             echo "Starting PR preview cleanup..."
             
             # Get yesterday's date in ISO format (Alpine/busybox compatible)
-            YESTERDAY=$(date -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d 2>/dev/null || date --date="yesterday" +%Y-%m-%d)
+            YESTERDAY=$(date -d "@$(($(date +%s) - 86400))" +%Y-%m-%d)
             echo "Looking for PRs closed after: $YESTERDAY"
             
-            # Get all closed PRs (without date filter first to debug)
-            echo "Fetching all closed PRs..."
-            ALL_CLOSED_PRS=$(gh pr list --state closed --limit 50 --json number,closedAt 2>&1)
-            echo "GitHub CLI response: $ALL_CLOSED_PRS"
+            # Get closed PRs from the last 24 hours using GitHub's search syntax
+            echo "Fetching recently closed PRs..."
+            CLOSED_PRS=$(gh pr list --state closed --search "closed:>${YESTERDAY}" --json number,closedAt 2>&1)
+            echo "GitHub CLI response: $CLOSED_PRS"
             
             # Check if we got valid JSON
-            if ! echo "$ALL_CLOSED_PRS" | jq empty 2>/dev/null; then
+            if ! echo "$CLOSED_PRS" | jq empty 2>/dev/null; then
               echo "Error: Invalid JSON response from GitHub CLI"
-              echo "Response was: $ALL_CLOSED_PRS"
+              echo "Response was: $CLOSED_PRS"
               exit 1
             fi
             
-            # Filter PRs closed in the last 24 hours and extract numbers
-            echo "Filtering PRs closed after $YESTERDAY..."
-            RECENT_CLOSED_PRS=$(echo "$ALL_CLOSED_PRS" | jq -r --arg yesterday "$YESTERDAY" '.[] | select(.closedAt > $yesterday) | .number')
+            # Extract PR numbers
+            PR_NUMBERS=$(echo "$CLOSED_PRS" | jq -r '.[].number')
             
-            if [ -z "$RECENT_CLOSED_PRS" ]; then
+            if [ -z "$PR_NUMBERS" ]; then
               echo "No recently closed PRs found"
               exit 0
             fi
             
-            echo "Recently closed PR numbers: $RECENT_CLOSED_PRS"
+            echo "Recently closed PR numbers: $PR_NUMBERS"
             
             # Clean up previews for recently closed PRs
-            echo "$RECENT_CLOSED_PRS" | while read -r pr_number; do
+            echo "$PR_NUMBERS" | while read -r pr_number; do
               if [ -n "$pr_number" ]; then
                 echo "Checking if preview exists for PR #$pr_number..."
                 if aws s3 ls s3://docs.mojaloop.io-root/pr/${pr_number}/ 2>/dev/null; then


### PR DESCRIPTION
to fetch recently closed PRs more efficiently

Updated the CircleCI configuration to enhance the PR cleanup process. The script now retrieves recently closed PRs using a more efficient date calculation and GitHub's search syntax, ensuring only relevant PRs are processed. This change simplifies the logic and improves the reliability of the cleanup operation.