### PR TITLE
fix(ci): enhance PR cleanup script to exclude open PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,13 +283,9 @@ jobs:
             set -x  # Enable debug output
             echo "Starting PR preview cleanup..."
             
-            # Get yesterday's date in ISO format (Alpine/busybox compatible)
-            YESTERDAY=$(date -d "@$(($(date +%s) - 86400))" +%Y-%m-%d)
-            echo "Looking for PRs closed after: $YESTERDAY"
-            
-            # Get closed PRs from the last 24 hours using GitHub's search syntax
-            echo "Fetching recently closed PRs..."
-            CLOSED_PRS=$(gh pr list --state closed --search "closed:>${YESTERDAY}" --json number,closedAt 2>&1)
+            # Get all closed PRs
+            echo "Fetching closed PRs..."
+            CLOSED_PRS=$(gh pr list --state closed --json number)
             echo "GitHub CLI response: $CLOSED_PRS"
             
             # Check if we got valid JSON
@@ -299,28 +295,46 @@ jobs:
               exit 1
             fi
             
-            # Extract PR numbers
-            PR_NUMBERS=$(echo "$CLOSED_PRS" | jq -r '.[].number')
+            # Get all open PRs to exclude them from cleanup
+            echo "Fetching open PRs..."
+            OPEN_PRS=$(gh pr list --state open --json number)
+            if ! echo "$OPEN_PRS" | jq empty 2>/dev/null; then
+              echo "Error: Invalid JSON response from GitHub CLI for open PRs"
+              echo "Response was: $OPEN_PRS"
+              exit 1
+            fi
             
-            if [ -z "$PR_NUMBERS" ]; then
-              echo "No recently closed PRs found"
+            # Create a list of open PR numbers for exclusion
+            OPEN_PR_NUMBERS=$(echo "$OPEN_PRS" | jq -r '.[].number')
+            echo "Open PR numbers: $OPEN_PR_NUMBERS"
+            
+            # Get all PR preview directories from S3
+            echo "Fetching PR preview directories from S3..."
+            S3_PREVIEWS=$(aws s3 ls s3://docs.mojaloop.io-root/pr/ 2>/dev/null | grep '^[[:space:]]*PRE [0-9]' | awk '{print $2}' | sed 's/\///')
+            
+            if [ -z "$S3_PREVIEWS" ]; then
+              echo "No PR previews found in S3"
               exit 0
             fi
             
-            echo "Recently closed PR numbers: $PR_NUMBERS"
+            echo "Found PR preview directories: $S3_PREVIEWS"
             
-            # Clean up previews for recently closed PRs
-            echo "$PR_NUMBERS" | while read -r pr_number; do
-              if [ -n "$pr_number" ]; then
-                echo "Checking if preview exists for PR #$pr_number..."
-                if aws s3 ls s3://docs.mojaloop.io-root/pr/${pr_number}/ 2>/dev/null; then
-                  echo "Cleaning up preview for PR #$pr_number"
-                  aws s3 rm s3://docs.mojaloop.io-root/pr/${pr_number} --recursive
-                  echo "Cleanup completed for PR #$pr_number"
-                else
-                  echo "No preview found for PR #$pr_number"
-                fi
+            # Clean up previews for PRs that are not open
+            echo "$S3_PREVIEWS" | while read -r pr_number; do
+              # Skip if PR number is empty
+              if [ -z "$pr_number" ]; then
+                continue
               fi
+              
+              # Check if this PR is still open
+              if echo "$OPEN_PR_NUMBERS" | grep -q "^${pr_number}$"; then
+                echo "PR #$pr_number is still open, skipping cleanup"
+                continue
+              fi
+              
+              echo "PR #$pr_number is not open, cleaning up preview..."
+              aws s3 rm s3://docs.mojaloop.io-root/pr/${pr_number} --recursive
+              echo "Cleanup completed for PR #$pr_number"
             done
             
             echo "PR preview cleanup completed"


### PR DESCRIPTION
Updated the CircleCI configuration to improve the PR cleanup process. The script now fetches all open PRs and excludes open PRs from cleanup, ensuring that only previews for closed PRs are removed. This change simplifies the logic and enhances the reliability of the cleanup operation.