### PR TITLE
chore: update bug triage steps to clear outdated info

### DIFF
--- a/docs/community/standards/triaging-bugs.md
+++ b/docs/community/standards/triaging-bugs.md
@@ -9,25 +9,14 @@ There is a bug [template](https://github.com/mojaloop/project/issues/new?assigne
 ### Once a bug is logged
 
 1. Typically, the bug is initially triaged in the [#ml-oss-bug-triage](https://mojaloop.slack.com/messages/CMCVBHPUH) public channel on Mojaloop Slack
-2. For Security and other sensitive issues, the bug is triaged on a private channel with current contributors, before information is made public at an appropriate time.
-3. During bug triage, priority and severity are assigned to the bug after majority consensus usually
+2. For Security and other sensitive issues, the bug is triaged on a private channel with current contributors, before information is made public at an appropriate time. Details for security issues are covered here: https://docs.mojaloop.io/community/contributing/cvd.html
+3. During bug triage, priority and severity are assigned to the bug after majority consensus and consultation with reporter(s)
 4. Based on the priority and severity the bug is taken up by the Core team or other contributors based on a collaborative effort.
-5. Once it is taken up, conversation and updates happen on the slack channl, but mostly on the issue itself.
+5. Once it is taken up, conversation and updates happen on GitHub issue and slack channel.
 
 ### Triage
 
 1. The discussion regarding the issue is open to a public for normal bugs / issues
-2. However, to start with, the voting rights are given to current contributors and stakeholders.
-3. Based on the discussions, a final call on the priority and severity of the issue is made by the Program Manager.
-4. If you think you need a vote, please reach out to Kim or Sam.
-5. Here are the voting members [14] for triaging bugs to start with.
-    1. Kim Walters
-    1. Lewis Daly
-    1. Miguel deBarros
-    1. Sam Kummary
-    1. Sri Miryala
-    1. Warren Carew
-    1. Vijay Guthi
-    1. Valentin Genev
-    1. Shashi Hirugade 
-6. The list and the process will be updated as it evolves, this is a proposal to start with do a Pilot on.
+2. Based on the discussions, a final call on the priority and severity of the issue is made by the Core team in consultation with the reporter(s).
+3. The list and the process will be updated as it evolves.
+4. Mojaloop bug triage slack channel #[ml-oss-bug-triage](https://mojaloop.slack.com/archives/CMCVBHPUH)


### PR DESCRIPTION
chore: update bug triage steps to clear outdated info