### PR TITLE
fix: update vue-loader override to valid version 15.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "overrides": {
     "vuepress": {
-      "vue-loader": "15.1.1"
+      "vue-loader": "15.10.2"
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug in package.json where a non-existent version of vue-loader (15.1.1) was specified in the overrides section. This was preventing a successful 'npm install' for new contributors. Updated to stable version 15.10.2.